### PR TITLE
Update MatchPlayerBase.cs to fix crash with observers

### DIFF
--- a/HeroesMatchTracker.Core/Models/MatchModels/MatchPlayerBase.cs
+++ b/HeroesMatchTracker.Core/Models/MatchModels/MatchPlayerBase.cs
@@ -139,7 +139,7 @@ namespace HeroesMatchTracker.Core.Models.MatchModels
             LeaderboardPortrait = Player.Character != "None" ? hero.HeroPortrait.LeaderboardImage() : null;
             Silenced = Player.IsSilenced;
             VoiceSilenced = Player.IsVoiceSilenced;
-            CharacterName = hero.Name;
+            CharacterName = hero?.Name ?? "None";
             PlayerName = Database.SettingsDb().UserSettings.IsBattleTagHidden ? HeroesHelpers.BattleTags.GetNameFromBattleTagName(playerInfo.BattleTagName) : playerInfo.BattleTagName;
             PlayerBattleTagName = playerInfo.BattleTagName;
             PlayerRegion = (Region)playerInfo.BattleNetRegionId;
@@ -161,6 +161,9 @@ namespace HeroesMatchTracker.Core.Models.MatchModels
                 Notes = playerInfo.Notes ?? string.Empty,
             };
 
+            if (Player.Team == 4)
+                return;
+            
             HeroDescription = new HeroDescription
             {
                 HeroName = hero.Name,


### PR DESCRIPTION
If 1 or more observers is present in the replay, it will fail to be displayed in summary view. This PR fixes that issue, hopefully without introducing more issues.

Related error log: [2021-01-20 00_29_20_app_crashed.txt](https://github.com/HeroesToolChest/HeroesMatchTracker/files/5839430/2021-01-20.00_29_20_app_crashed.txt)

This changeset stubs in "None" for CharacterName and returns prior to hero description initialization if team is 4 (observers.)